### PR TITLE
Validador: atualizando dependencias

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module validador
 go 1.14
 
 require (
-	github.com/dadosjusbr/coletores v0.0.0-20210827150800-92e4a6a7f133
-	github.com/dadosjusbr/proto v0.0.0-20211015231253-b8391964395a
+	github.com/dadosjusbr/coletores v0.0.0-20210928113650-4c03e4fa3b74
+	github.com/dadosjusbr/proto v0.0.0-20211129103514-9c088f1a601c
 	github.com/frictionlessdata/datapackage-go v0.0.0-20210810130302-98883c9586e9
 	github.com/frictionlessdata/tableschema-go v1.1.3
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,17 @@
 github.com/dadosjusbr/coletores v0.0.0-20210827150800-92e4a6a7f133 h1:0cmjnsQiiQXlhYhj+mIMgjnWL9iyH1piXQy2g1MHlbA=
 github.com/dadosjusbr/coletores v0.0.0-20210827150800-92e4a6a7f133/go.mod h1:m9opDykSJIwaf+veICpleWMranaaWEbx5RNQhKZAgXU=
+github.com/dadosjusbr/coletores v0.0.0-20210928113650-4c03e4fa3b74 h1:biTIncJC0XYYqAVEJHJRI5dTUgEp9K7AfTrUj9JzvNc=
+github.com/dadosjusbr/coletores v0.0.0-20210928113650-4c03e4fa3b74/go.mod h1:m9opDykSJIwaf+veICpleWMranaaWEbx5RNQhKZAgXU=
 github.com/dadosjusbr/proto v0.0.0-20211015231253-b8391964395a h1:JkMyCT92jfqi06dVCjT+J0Kg4M6P24I0S6WQmSN62ns=
 github.com/dadosjusbr/proto v0.0.0-20211015231253-b8391964395a/go.mod h1:O+J9NWE4o4IkP6XN7CMZ8TnPxrbkqyuIp/Wvvst4W/s=
+github.com/dadosjusbr/proto v0.0.0-20211129103514-9c088f1a601c h1:4b9vaEgN+747yQ5N7Pao/7zcwlD8mvTCH9VUjZM0jFY=
+github.com/dadosjusbr/proto v0.0.0-20211129103514-9c088f1a601c/go.mod h1:cUy4r8q1n58ClC4IlsAQ49nr8hIDwA01HiTYAJ1eMVc=
 github.com/frictionlessdata/datapackage-go v0.0.0-20210810130302-98883c9586e9 h1:gwjq5qszD6CxbHQpBzmLH/DXztQeeVszCDVKsrBW/ww=
 github.com/frictionlessdata/datapackage-go v0.0.0-20210810130302-98883c9586e9/go.mod h1:d6CbzM3Xw9JOsz0AemqOX8DJa315xow0hsw6eTgiDKE=
 github.com/frictionlessdata/tableschema-go v0.1.5-0.20190521014818-f9bf38926664/go.mod h1:OfuE6zbfQdlwx5q9vf5XWXEGJ0LYZcd9ML3zme5rP3k=
 github.com/frictionlessdata/tableschema-go v1.1.3 h1:I6/UYXX2KTzcZrDUcXjIjWMD5gz9kdmua0wFaeIvNSc=
 github.com/frictionlessdata/tableschema-go v1.1.3/go.mod h1:OfuE6zbfQdlwx5q9vf5XWXEGJ0LYZcd9ML3zme5rP3k=
+github.com/gocarina/gocsv v0.0.0-20200827134620-49f5c3fa2b3e h1:f9zU2ojLUYe8f/uWnetnr0p6TnAGQBCV/WdPKxodBqA=
 github.com/gocarina/gocsv v0.0.0-20200827134620-49f5c3fa2b3e/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=


### PR DESCRIPTION
## Atualizando dependências para funcionar com o proto 0.7

Com a adição de novas extensões de arquivos no proto, é necessário atualizar o validador para não dar erro.